### PR TITLE
xt_lua: do not fail if network namespace is already present

### DIFF
--- a/src/xt_lua.c
+++ b/src/xt_lua.c
@@ -1068,13 +1068,18 @@ static int __net_init xt_lua_net_init(struct net *net)
 	if (netlink_family == NETLINK_GENERIC) {
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
 		ret = genl_register_family(&genl_nflua_family);
+		if (ret == -EEXIST)
+			return 0; /** do nothing */
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(3, 11, 0)
 		ret = genl_register_family_with_ops(&genl_nflua_family,
 						    &genl_nflua_ops[0],
 						    ARRAY_SIZE(genl_nflua_ops));
+		if (ret == -EEXIST)
+			return 0;
 #else
 		ret = genl_register_family(&genl_nflua_family);
-
+		if (unlikely(ret == -EEXIST))
+			return 0;
 		if (unlikely(ret < 0)) {
 			printk(KERN_ERR
 			       "cannot register generic netlink family: %d\n",


### PR DESCRIPTION
Do not block the creation of new network
namespaces by other apps